### PR TITLE
Add Terraform deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,75 @@
+name: Terraform Deploy
+
+on:
+  pull_request:
+    branches: [main]
+    paths: ['**.tf', '**.tfvars']
+  push:
+    branches: [main]
+    paths: ['**.tf', '**.tfvars']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  TF_VERSION: "1.14.8"
+  AWS_REGION: "ap-southeast-3"
+
+jobs:
+  plan:
+    name: Terraform Plan (Staging)
+    runs-on: piksel-staging-runners
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Write secrets.auto.tfvars
+        run: echo '${{ secrets.STAGING_TFVARS }}' > staging/secrets.auto.tfvars
+
+      - name: Terraform Init
+        run: terraform -chdir=staging init
+
+      - name: Terraform Plan
+        id: plan
+        run: |
+          terraform -chdir=staging plan \
+            -var="pg_host=" \
+            -var="pg_port=5432" \
+            -no-color 2>&1 | tee plan_output.txt
+
+      - name: Comment PR with plan
+        if: always() && steps.plan.outcome != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const plan = fs.readFileSync('plan_output.txt', 'utf8');
+            const body = `## Terraform Plan (Staging)\n\n\`\`\`\n${plan.substring(0, 60000)}\n\`\`\``;
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body
+            });
+
+  apply:
+    name: Terraform Apply (Staging)
+    runs-on: piksel-staging-runners
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Write secrets.auto.tfvars
+        run: echo '${{ secrets.STAGING_TFVARS }}' > staging/secrets.auto.tfvars
+
+      - name: Terraform Init
+        run: terraform -chdir=staging init
+
+      - name: Terraform Apply
+        run: |
+          terraform -chdir=staging apply \
+            -var="pg_host=" \
+            -var="pg_port=5432" \
+            -auto-approve


### PR DESCRIPTION
## Summary
- Add `.github/workflows/deploy.yml` for Terraform plan/apply on ARC runners
- **Plan** on PRs that touch `.tf`/`.tfvars` files, with PR comment
- **Apply** on push to main (merge) or manual dispatch
- Runs on `piksel-staging-runners` (ARC, inside VPC) for direct RDS access
- Overrides `pg_host`/`pg_port` for in-VPC connectivity (no port-forward needed)

## Test Plan
- [ ] This PR should trigger the plan job on the ARC runner
- [ ] Verify the plan output is commented on this PR
- [ ] After merge, verify apply runs and succeeds