### PR TITLE
Fix EFS SG: standalone rules so admin NFS ingress persists

### DIFF
--- a/aws-eks-cluster/README.md
+++ b/aws-eks-cluster/README.md
@@ -94,6 +94,8 @@ No requirements.
 | [aws_efs_mount_target.data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_mount_target) | resource |
 | [aws_iam_policy.assume_ecr_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_security_group.efs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.efs_egress_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.efs_ingress_nodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_eks_cluster_auth.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
 
 ## Inputs

--- a/aws-eks-cluster/efs.tf
+++ b/aws-eks-cluster/efs.tf
@@ -21,26 +21,9 @@ module "efs_csi_irsa_role" {
 
 # --- Security group for EFS ---
 resource "aws_security_group" "efs" {
-  #checkov:skip=CKV_AWS_382:Standard unrestricted egress for EFS. NFS mount requires outbound connectivity.
   name_prefix = "${local.cluster}-efs-"
   description = "Security group for EFS file system access from EKS cluster"
   vpc_id      = var.vpc_id
-
-  ingress {
-    from_port       = 2049
-    to_port         = 2049
-    protocol        = "tcp"
-    security_groups = [module.eks.node_security_group_id]
-    description     = "NFS traffic from EKS cluster"
-  }
-
-  egress {
-    description = "Allow all outbound traffic from EFS"
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
 
   lifecycle {
     create_before_destroy = true
@@ -49,6 +32,27 @@ resource "aws_security_group" "efs" {
   tags = merge(local.tags, {
     Name = "${local.cluster}-efs-sg"
   })
+}
+
+resource "aws_security_group_rule" "efs_ingress_nodes" {
+  description              = "NFS traffic from EKS cluster nodes"
+  type                     = "ingress"
+  from_port                = 2049
+  to_port                  = 2049
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.efs.id
+  source_security_group_id = module.eks.node_security_group_id
+}
+
+resource "aws_security_group_rule" "efs_egress_all" {
+  #checkov:skip=CKV_AWS_382:Standard unrestricted egress for EFS. NFS mount requires outbound connectivity.
+  description       = "Allow all outbound traffic from EFS"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.efs.id
 }
 
 # --- EFS File System ---


### PR DESCRIPTION
The EFS security group defined its rules inline while the admin workstation attaches a standalone rule to the same SG; the AWS provider reverts the standalone rule on each apply, silently dropping the admin's NFS 2049 traffic. This moves the node ingress and egress to standalone aws_security_group_rule resources so external rules coexist. No resource replacement and no change to the SG ID, EFS filesystem ID, or module outputs.