### PR TITLE
Widen public bucket CORS for range requests, drop expiration

### DIFF
--- a/aws-eks-cluster/README.md
+++ b/aws-eks-cluster/README.md
@@ -89,7 +89,7 @@ No requirements.
 
 | Name | Type |
 |------|------|
-| [aws_efs_access_point.coastline_readonly](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_access_point) | resource |
+| [aws_efs_access_point.coastlines](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_access_point) | resource |
 | [aws_efs_backup_policy.data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_backup_policy) | resource |
 | [aws_efs_file_system.data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system) | resource |
 | [aws_efs_mount_target.data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_mount_target) | resource |
@@ -132,7 +132,7 @@ No requirements.
 | <a name="output_cluster_oidc_provider_arn"></a> [cluster\_oidc\_provider\_arn](#output\_cluster\_oidc\_provider\_arn) | EKS Cluster OIDC Provider ARN |
 | <a name="output_cluster_security_group_id"></a> [cluster\_security\_group\_id](#output\_cluster\_security\_group\_id) | Security group ID attached to the EKS cluster control plane ENIs |
 | <a name="output_cluster_tls_certificate_sha1_fingerprint"></a> [cluster\_tls\_certificate\_sha1\_fingerprint](#output\_cluster\_tls\_certificate\_sha1\_fingerprint) | EKS Cluster TLS Certificate SHA1 Fingerprint |
-| <a name="output_efs_coastline_readonly_access_point_id"></a> [efs\_coastline\_readonly\_access\_point\_id](#output\_efs\_coastline\_readonly\_access\_point\_id) | EFS access point ID for read-only coastline mount (used by argo-workflows) |
+| <a name="output_efs_coastlines_access_point_id"></a> [efs\_coastlines\_access\_point\_id](#output\_efs\_coastlines\_access\_point\_id) | EFS access point ID for the shared coastlines mount (used by argo-workflows and jupyterhub) |
 | <a name="output_efs_csi_irsa_role_arn"></a> [efs\_csi\_irsa\_role\_arn](#output\_efs\_csi\_irsa\_role\_arn) | IAM role ARN for EFS CSI driver controller service account |
 | <a name="output_efs_filesystem_id"></a> [efs\_filesystem\_id](#output\_efs\_filesystem\_id) | EFS filesystem ID for CSI driver and StorageClasses |
 | <a name="output_efs_security_group_id"></a> [efs\_security\_group\_id](#output\_efs\_security\_group\_id) | Security group ID of the EFS mount targets (for granting NFS access to in-VPC clients) |

--- a/aws-s3-bucket/README.md
+++ b/aws-s3-bucket/README.md
@@ -19,7 +19,7 @@ No modules.
 |------|------|
 | [aws_s3_bucket.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_acl.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
-| [aws_s3_bucket_cors_configuration.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_cors_configuration) | resource |
+| [aws_s3_bucket_cors_configuration.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_cors_configuration) | resource |
 | [aws_s3_bucket_lifecycle_configuration.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_ownership_controls.public_ownership](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.public_read_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
@@ -32,7 +32,6 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | Default tags to apply to all resources | `map(string)` | `{}` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The name of the environment | `string` | n/a | yes |
-| <a name="input_lifecycle_expiration_days"></a> [lifecycle\_expiration\_days](#input\_lifecycle\_expiration\_days) | Number of days before objects expire. Override per environment (e.g. staging=90) | `number` | `365` | no |
 | <a name="input_project"></a> [project](#input\_project) | The name of the project | `string` | n/a | yes |
 
 ## Outputs

--- a/aws-s3-bucket/main.tf
+++ b/aws-s3-bucket/main.tf
@@ -48,12 +48,29 @@ resource "aws_s3_bucket_acl" "public" {
   acl    = "public-read"
 }
 
-resource "aws_s3_bucket_cors_configuration" "example" {
+resource "aws_s3_bucket_cors_configuration" "public" {
   bucket = aws_s3_bucket.public.id
   cors_rule {
-    allowed_methods = ["GET"]
+    allowed_methods = ["GET", "HEAD"]
     allowed_origins = ["*"]
+    allowed_headers = ["*"]
+    expose_headers = [
+      "Content-Length",
+      "Content-Range",
+      "Content-Encoding",
+      "Content-Type",
+      "ETag",
+      "Accept-Ranges",
+      "Last-Modified",
+      "Cache-Control",
+    ]
+    max_age_seconds = 3600
   }
+}
+
+moved {
+  from = aws_s3_bucket_cors_configuration.example
+  to   = aws_s3_bucket_cors_configuration.public
 }
 
 resource "aws_s3_bucket_policy" "public_read_policy" {
@@ -86,8 +103,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "public" {
   bucket = aws_s3_bucket.public.id
 
   rule {
-    id     = "expire-old-data"
+    id     = "hygiene-and-tiering"
     status = "Enabled"
+
+    filter {}
 
     abort_incomplete_multipart_upload {
       days_after_initiation = 7
@@ -95,11 +114,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "public" {
 
     transition {
       days          = 60
-      storage_class = "ONEZONE_IA"
-    }
-
-    expiration {
-      days = var.lifecycle_expiration_days
+      storage_class = "INTELLIGENT_TIERING"
     }
   }
 }

--- a/aws-s3-bucket/variables.tf
+++ b/aws-s3-bucket/variables.tf
@@ -13,9 +13,3 @@ variable "default_tags" {
   type        = map(string)
   default     = {}
 }
-
-variable "lifecycle_expiration_days" {
-  description = "Number of days before objects expire. Override per environment (e.g. staging=90)"
-  type        = number
-  default     = 365
-}

--- a/staging/README.md
+++ b/staging/README.md
@@ -63,8 +63,8 @@ Edit `backup.sh` if needed:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.46.0 |
-| <a name="provider_aws.aws"></a> [aws.aws](#provider\_aws.aws) | 6.46.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
+| <a name="provider_aws.aws"></a> [aws.aws](#provider\_aws.aws) | 6.53.0 |
 | <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | 2.4.0 |
 
 ## Modules

--- a/staging/main.tf
+++ b/staging/main.tf
@@ -18,10 +18,9 @@ module "networks" {
 module "s3_bucket" {
   source = "../aws-s3-bucket"
 
-  project                   = var.project
-  environment               = var.environment
-  default_tags              = var.default_tags
-  lifecycle_expiration_days = 365
+  project      = var.project
+  environment  = var.environment
+  default_tags = var.default_tags
 }
 
 module "website" {


### PR DESCRIPTION
Prep for serving PMTiles from piksel-staging-public-data via tileserver-gl.

CORS: widened for range requests. Lifecycle: dropped expiration (data should persist), swapped ONEZONE_IA → INTELLIGENT_TIERING to get multi-AZ durability.
