### PR TITLE
Tighten website CSP: drop unsafe-eval and https: wildcards

### DIFF
--- a/aws-s3-static-hosting/main.tf
+++ b/aws-s3-static-hosting/main.tf
@@ -279,7 +279,7 @@ resource "aws_cloudfront_response_headers_policy" "security" {
 
     content_security_policy {
       override                = true
-      content_security_policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https: blob:; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' https:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+      content_security_policy = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
     }
   }
 }


### PR DESCRIPTION
## Summary
Addresses 2 of the 4 medium CSP findings (ZAP Plugin 10055) on `staging.piksel.big.go.id`, in the CloudFront `website-security-headers` response-headers policy.

| Finding | Directive | Change |
|---|---|---|
| CSP: script-src unsafe-eval | `script-src` | removed `'unsafe-eval'` |
| CSP: Wildcard Directive | `img-src` | removed bare `https:` (kept `data:` `blob:`) |
| CSP: Wildcard Directive | `connect-src` | removed bare `https:` → `'self'` |

New policy:
```
default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
```

## Deferred (not in this PR)
- **script-src `unsafe-inline`** — needs a build-time hash pipeline; site inspection confirms only 3 stable inline-script hashes are required.
- **style-src `unsafe-inline`** — no clean fix; ~778 inline `style=` attributes, mostly Docusaurus theme/config-injected. Separate decision.

## Basis
Confirmed via a local `main-website` production build: no external hosts (fonts self-hosted, no analytics/APIs), so `connect-src`/`img-src` collapse to `'self'`. The only eval-family code is webpack's dead-code global probe (`new Function` fallback), unreachable in the site's target browsers.

## Verification after apply
- `curl -sI https://staging.piksel.big.go.id | grep -i content-security`
- Browser smoke-test: pages load, images render, **no CSP `eval` violation in console** (validates the `unsafe-eval` removal), locale switch id/en.