### PR TITLE
Close CSP script-src unsafe-inline via build-derived hashes

### DIFF
--- a/aws-s3-static-hosting/main.tf
+++ b/aws-s3-static-hosting/main.tf
@@ -279,7 +279,7 @@ resource "aws_cloudfront_response_headers_policy" "security" {
 
     content_security_policy {
       override                = true
-      content_security_policy = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+      content_security_policy = "default-src 'self'; script-src 'self' 'sha256-cwuLNOro1rKKV3tYMKUxJTCXwdmGh2ndC/hn1LmXyjQ=' 'sha256-0MUyFJhUwQbJbxdRddDw1q7CMNQ//leUWFbuI6XcmZo=' 'sha256-l75NlFdSAwyAIr8HS79hfv4NDLEpCvkAqGGjpbeKw2M='; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
     }
   }
 }


### PR DESCRIPTION
Replaces `script-src 'unsafe-inline'` with SHA-256 hashes of the site's only 3 executable inline scripts (theme-init + 2 base-URL banners).

Hashes taken from the live 3.10.2 build, confirmed across 6 page types. Docusaurus is version-pinned, so they only change on a deliberate bump or theme-config edit.

Verify after apply: `curl -sI ... | grep -i content-security` + browser console shows no script-src violation, correct theme, id/en OK.